### PR TITLE
Optionally Save Synth Output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,7 @@ runs:
         echo "stacks=$(jq --compact-output --null-input '$ARGS.positional' --args -- $(ls cdktf.out/stacks))" >> $GITHUB_OUTPUT
 
     - name: Save Assets
+      if: ${{ inputs.save }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.jobid_action.outputs.job_id }}

--- a/action.yml
+++ b/action.yml
@@ -2,11 +2,9 @@ name: cdktf-synth
 description: Synthesize CDKTF stacks in order to deploy infrastructure as code. This project is for demonstration purposes only.
 inputs:
   github_token:
-    description: GITHUB_TOKEN to use GitHub API. Simply specify `secrets.GITHUB_TOKEN`.
-    required: true
+    description: GITHUB_TOKEN to use GitHub API. Simply specify `secrets.GITHUB_TOKEN`. This is required if you wish to save assets.
   job_name:
-    description: jobs.<job-id>.name of this workflow job. This is needed to get the job ID via query.
-    required: true
+    description: jobs.<job-id>.name of this workflow job. This is required if you wish to save assets.
   ref:
     description: Branch/Commit/Tag to use
     default: main
@@ -40,6 +38,7 @@ runs:
   using: composite
   steps:
     - id: jobid_action
+      if: ${{ inputs.save == 'true' }}
       uses: Tiryoh/gha-jobid-action@v1
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -8,17 +8,17 @@ inputs:
     description: jobs.<job-id>.name of this workflow job. This is needed to get the job ID via query.
     required: true
   ref:
-    default: main
     description: Branch/Commit/Tag to use
+    default: main
     type: string
   terraform_version:
-    default: 1.8.0
     description: The version of Terraform to use
-    type: string
+    default: 1.8.0
+    required: false
   working_directory:
-    default: ./
     description: Working directory path that contains your cdktf code.
-    type: string
+    default: ./
+    required: false
   output:
     default: cdktf.out
     description: Output directory for the synthesized Terraform config

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
         echo "stacks=$(jq --compact-output --null-input '$ARGS.positional' --args -- $(ls cdktf.out/stacks))" >> $GITHUB_OUTPUT
 
     - name: Save Assets
-      if: ${{ inputs.save }}
+      if: ${{ inputs.save == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.jobid_action.outputs.job_id }}

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,48 @@
 name: cdktf-synth
 description: Synthesize CDKTF stacks in order to deploy infrastructure as code. This project is for demonstration purposes only.
 inputs:
+  github_token:
+    description: GITHUB_TOKEN to use GitHub API. Simply specify `secrets.GITHUB_TOKEN`.
+    required: true
+  job_name:
+    description: jobs.<job-id>.name of this workflow job. This is needed to get the job ID via query.
+    required: true
   ref:
-    description: Branch/Commit/Tag to use
     default: main
+    description: Branch/Commit/Tag to use
     type: string
   terraform_version:
-    description: The version of Terraform to use
     default: 1.8.0
-    required: false
+    description: The version of Terraform to use
+    type: string
   working_directory:
-    description: Working directory path that contains your cdktf code.
     default: ./
-    required: false
+    description: Working directory path that contains your cdktf code.
+    type: string
+  output:
+    default: cdktf.out
+    description: Output directory for the synthesized Terraform config
+    type: string
+  save:
+    default: false
+    description: When set to true, save the generated files to a GitHub Artifact.
+    type: boolean
+  
 outputs:
   stacks:
     description: JSON array of strings, containing the names of the CDKTF stacks that were synthesized.
     value: ${{ steps.synth.outputs.stacks }}
+
 runs:
   using: composite
   steps:
+    - id: jobid_action
+      uses: Tiryoh/gha-jobid-action@v1
+      with:
+        github_token: ${{ inputs.GITHUB_TOKEN }}
+        job_name: ${{ inputs.job_name }}
+        per_page: 100
+
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform_version }}
@@ -55,3 +78,9 @@ runs:
       run: |
         npx cdktf synth
         echo "stacks=$(jq --compact-output --null-input '$ARGS.positional' --args -- $(ls cdktf.out/stacks))" >> $GITHUB_OUTPUT
+
+    - name: Save Assets
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.jobid_action.outputs.job_id }}
+        path: ${{ inputs.working_directory }}/${{ inputs.output }}

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ outputs:
   stacks:
     description: JSON array of strings, containing the names of the CDKTF stacks that were synthesized.
     value: ${{ steps.synth.outputs.stacks }}
+  job_id:
+    description: ID of this job
+    value: ${{ steps.jobid_action.outputs.job_id }}
 
 runs:
   using: composite


### PR DESCRIPTION
## What

These changes save the `cdktf.out` directory generated by `cdktf synth` so they can be reused by other jobs.

## Why

Dependent jobs in a workflow that run CDKTF commands can reuse the files generated by synth, but those files need to first be saved.

## How

Upload the directory into a GitHub Artifact with the name of the job ID, so they can be identified and downloaded later.

## Testing

Update existing references to point to this branch.

```yaml
- uses: snapsheet/cdktf-synth@SRE-2504-optionally-save-synth-output
  id: synth
  with:
    ref: ${{ inputs.ref }}
    terraform_version: ${{ inputs.terraform_version }}
```

Run a test confirming that it works as expected without any additional options.

Update the configuration to use `job_name`, `github_token`, and `save`.

```yaml
- uses: snapsheet/cdktf-synth@SRE-2504-optionally-save-synth-output
  id: synth
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
    job_name: CDKTF Synth
    ref: ${{ github.event.repository.default_branch }}
    terraform_version: ${{ inputs.terraform_version }}
    save: true
```

Run a test and confirm that the workflow runs faster now that a synth is no longer needed.