### PR TITLE
Release 0.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 name: cdktf-synth
 description: Synthesize CDKTF stacks in order to deploy infrastructure as code. This project is for demonstration purposes only.
 inputs:
+  github_token:
+    description: GITHUB_TOKEN to use GitHub API. Simply specify `secrets.GITHUB_TOKEN`. This is required if you wish to save assets.
+  job_name:
+    description: jobs.<job-id>.name of this workflow job. This is required if you wish to save assets.
   ref:
     description: Branch/Commit/Tag to use
     default: main
@@ -13,13 +17,34 @@ inputs:
     description: Working directory path that contains your cdktf code.
     default: ./
     required: false
+  output:
+    default: cdktf.out
+    description: Output directory for the synthesized Terraform config
+    type: string
+  save:
+    default: false
+    description: When set to true, save the generated files to a GitHub Artifact.
+    type: boolean
+  
 outputs:
   stacks:
     description: JSON array of strings, containing the names of the CDKTF stacks that were synthesized.
     value: ${{ steps.synth.outputs.stacks }}
+  job_id:
+    description: ID of this job
+    value: ${{ steps.jobid_action.outputs.job_id }}
+
 runs:
   using: composite
   steps:
+    - id: jobid_action
+      if: ${{ inputs.save == 'true' }}
+      uses: Tiryoh/gha-jobid-action@v1
+      with:
+        github_token: ${{ inputs.GITHUB_TOKEN }}
+        job_name: ${{ inputs.job_name }}
+        per_page: 100
+
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ inputs.terraform_version }}
@@ -55,3 +80,10 @@ runs:
       run: |
         npx cdktf synth
         echo "stacks=$(jq --compact-output --null-input '$ARGS.positional' --args -- $(ls cdktf.out/stacks))" >> $GITHUB_OUTPUT
+
+    - name: Save Assets
+      if: ${{ inputs.save == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.jobid_action.outputs.job_id }}
+        path: ${{ inputs.working_directory }}/${{ inputs.output }}


### PR DESCRIPTION
* Add inputs and steps needed to upload artifacts associated with this job.

* Only save if the option is passed.

* Save the id of this job as an output.

* Make token and job name optional for backward compatibility.